### PR TITLE
fix(ci): update GitHub labeler to V5+ format and improve configuration

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,34 @@
 # Configuration for https://github.com/actions/labeler (V6+ format)
 
+# Label for any changes to Python files
+lang-python:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.py"
+
+# Label for any changes to tests
+testing:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "tests/**/*"
+          - "**/*test*.py"
+
+# Label for any changes to CI/CD
+internal:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/**/*"
+          - "**/*.yml"
+          - "**/*.yaml"
+          - "deploy.sh"
+
+# Label for infrastructure changes
+infrastructure:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "cloudformation-template.yaml"
+          - "**/infrastructure/**/*"
+
 # Label for any changes to dependencies
 upgrade:
   - changed-files:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,33 +1,45 @@
-# Configuration for https://github.com/actions/labeler
-
-# Label for any changes to Python files
-lang-python:
-  - "**/*.py"
-
-# Label for any changes to tests
-testing:
-  - "tests/**/*"
-  - "**/*test*.py"
-
-# Label for any changes to CI/CD
-internal:
-  - ".github/**/*"
-  - "**/*.yml"
-  - "**/*.yaml"
-  - "deploy.sh"
+# Configuration for https://github.com/actions/labeler (V6+ format)
 
 # Label for any changes to dependencies
 upgrade:
-  - "requirements*.txt"
-  - "pyproject.toml"
-  - "uv.lock"
-
-# Label for infrastructure changes
-infrastructure:
-  - "cloudformation-template.yaml"
-  - "**/infrastructure/**/*"
+  - changed-files:
+      - any-glob-to-any-file:
+          - "requirements*.txt"
+          - "pyproject.toml"
+          - "uv.lock"
 
 # Label for any changes to the main application logic
 feature:
-  - "lambda_function.py"
-  - "src/**/*"
+  - changed-files:
+      - any-glob-to-any-file:
+          - "lambda_function.py"
+          - "src/**/*"
+
+# Label for documentation changes
+docs:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "README.md"
+          - "**/*.md"
+          - "docs/**/*"
+
+# Label for bug fixes (based on branch name)
+bug:
+  - head-branch: ["fix/", "hotfix/", "bugfix/"]
+
+# Label for refactoring changes (based on branch name)
+refactor:
+  - head-branch: ["refactor/", "cleanup/"]
+
+# Label for security-related changes (based on branch name or files)
+security:
+  - any:
+      - head-branch: ["security/", "sec/"]
+      - changed-files:
+          - any-glob-to-any-file:
+              - "**/security/**/*"
+              - "**/*security*"
+
+# Label for breaking changes (based on branch name)
+breaking:
+  - head-branch: ["breaking/", "major/"]

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,6 @@
 name: Labels
 on:
   pull_request_target:
-    branches: [main]
     types:
       - opened
       - synchronize
@@ -20,6 +19,8 @@ jobs:
     steps:
       - uses: actions/labeler@v6
         if: ${{ github.event.action != 'labeled' && github.event.action != 'unlabeled' }}
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - run: echo "Done adding labels"
   # Run this after labeler applied labels
   check-labels:
@@ -31,5 +32,5 @@ jobs:
     steps:
       - uses: docker://agilepathway/pull-request-label-checker:latest
         with:
-          one_of: breaking,security,feature,bug,refactor,upgrade,docs,lang-all,internal
+          one_of: breaking,security,feature,bug,refactor,upgrade,docs
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -17,10 +17,17 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        if: ${{ github.event.action != 'labeled' && github.event.action != 'unlabeled' }}
+        with:
+          # Checkout the head ref so we get the PR changes
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/labeler@v6
         if: ${{ github.event.action != 'labeled' && github.event.action != 'unlabeled' }}
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml
       - run: echo "Done adding labels"
   # Run this after labeler applied labels
   check-labels:
@@ -32,5 +39,5 @@ jobs:
     steps:
       - uses: docker://agilepathway/pull-request-label-checker:latest
         with:
-          one_of: breaking,security,feature,bug,refactor,upgrade,docs
+          one_of: breaking,security,feature,bug,refactor,upgrade,docs,lang-python,testing,internal,infrastructure
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -7,6 +7,10 @@
       "args": [
         "mcp-server-git"
       ]
+    },
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/"
     }
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -31,6 +31,17 @@
         ],
         "editor.trimAutoWhitespace": true
     },
+    // YAML Configuration
+    "[yaml]": {
+        "editor.tabSize": 2,
+        "editor.insertSpaces": true,
+        "editor.detectIndentation": false
+    },
+    "[yml]": {
+        "editor.tabSize": 2,
+        "editor.insertSpaces": true,
+        "editor.detectIndentation": false
+    },
     // MyPy Type Checking
     "mypy-type-checker.enable": true,
     "mypy-type-checker.args": [


### PR DESCRIPTION
- Migrate labeler.yml to new V5+ format with changed-files syntax
- Add comprehensive labeling rules including docs, bug, refactor, security, and breaking
- Remove branch restriction from labeler workflow to apply to all PRs
- Add explicit repo-token configuration for better reliability
- Enhance pattern matching with any-glob-to-any-file syntax