### PR TITLE
docs: improve deployment instructions with layer update guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,10 @@ translator-linebot/
 4. **Run the deployment script**:
 
    ```bash
-   ./deploy.sh
+   ./deploy.sh --update-layer
    ```
+
+   > The argument `--update-layer` will only need to added for the first deployment or when dependencies change.
 
 5. **Update LINE Webhook URL**:
 


### PR DESCRIPTION
- Add explanatory note about when --update-layer is needed
- Clarify that the flag is required for first deployment or dependency changes